### PR TITLE
Support category exclusions

### DIFF
--- a/app/assets/javascripts/ledgers.coffee
+++ b/app/assets/javascripts/ledgers.coffee
@@ -2,6 +2,11 @@
 # Calls functions after page has completely loaded
 $(document).on 'turbolinks:load', ->
     #
+    # adds an onclick event to add category exclusion fields to the ledger form
+    $('#add-category-exclusion').on('click', (event) ->
+        addCategoryExclusion();
+    );
+    #
     # adds an onclick event delegator to watch for clicks in description
     $("#ledger").on("click", "td[id*=-description]", (event) ->
         toggleText(this, $(this.parentNode).data('description').trim(), 30);
@@ -34,6 +39,30 @@ $(document).on 'turbolinks:load', ->
     # add handlers to ledger-summary 'more' links
     $('.ledger-summary table a').each ->
         $(this).click(showSummarySubcategories.bind(null, this));
+#
+# this function handles sending and receiving an AJAX response to add a ledger
+# field to the form
+@addCategoryExclusion = () ->
+    container = $('#category-exclusions-container')
+    url = '/category_exclusions/form_fields?child_index='
+    url += container.find('div').length
+    #
+    success = (html) ->
+        $(html).appendTo(container)
+    #
+    failure = (_, type, exception) ->
+        console.error(type)
+        console.dir(exception)
+    #
+    args = {
+        type: 'GET',
+        dataType: 'html',
+        error: failure,
+        success: success,
+        url: url
+    }
+    #
+    $.ajax(args)
 #
 # toggles text based on the content length
 @toggleText = (element, fullText, len) ->

--- a/app/assets/stylesheets/_base.scss
+++ b/app/assets/stylesheets/_base.scss
@@ -14,6 +14,15 @@ pre {
 a {
     color: #000;
 
+    &.remove {
+        color: #F00;
+
+        &:hover {
+            color: #D00;
+            background-color: #fff;
+        }
+    }
+
     &:visited {
         color: #666;
     }

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -1,73 +1,84 @@
-div {
-    &.actions, &.field {
-        margin-bottom: 10px;
-    }
-}
+form {
+    div {
+        h4 {
+            width: 33%;
 
-label {
-    display: inline-block;
+            border-bottom: solid 1px;
+        }
 
-    span {
-        display: inline-block;
-        width: 7em;
-    }
-
-    ul {
-        margin: 0em;
-        list-style: none;
-    }
-}
-
-input, select {
-    &.small {
-        width: 5em;
+        &.actions, &.field {
+            margin-bottom: 10px;
+        }
     }
 
-    &.medium {
-        width: 7em;
+    label {
+        display: block;
+
+        padding-bottom: 1em;
+
+        span {
+            display: inline-block;
+            width: 8em;
+        }
+
+        ul {
+            margin: 0em;
+            list-style: none;
+        }
     }
 
-    &.large {
-        width: 10em;
+    input, select {
+        &.small {
+            width: 5em;
+        }
+
+        &.medium {
+            width: 7em;
+        }
+
+        &.large {
+            width: 10em;
+        }
+
+        &.disabled {
+            color: rgba(0, 0, 0, 0.5);
+            pointer-events: none;
+        }
     }
 
-    &.disabled {
-        color: rgba(0, 0, 0, 0.5);
-        pointer-events: none;
-    }
-}
-
-#notice {
-    color: green;
-}
-
-.field_with_errors {
-    padding: 2px;
-    background-color: red;
-    display: table;
-}
-
-#error_explanation {
-    width: 450px;
-    border: 2px solid red;
-    padding: 7px;
-    padding-bottom: 0;
-    margin-bottom: 20px;
-    background-color: #f0f0f0;
-
-    h2 {
-        text-align: left;
-        font-weight: bold;
-        padding: 5px 5px 5px 15px;
-        font-size: 12px;
-        margin: -7px;
-        margin-bottom: 0;
-        background-color: #c00;
-        color: #fff;
+    #notice {
+        color: green;
     }
 
-    ul li {
-        font-size: 12px;
-        list-style: square;
+    .field_with_errors {
+        padding: 2px;
+        background-color: red;
+        display: table;
     }
+
+    #error_explanation {
+        width: 450px;
+        border: 2px solid red;
+        padding: 7px;
+        padding-bottom: 0;
+        margin-bottom: 20px;
+        background-color: #f0f0f0;
+
+        h2 {
+            text-align: left;
+            font-weight: bold;
+            padding: 5px 5px 5px 15px;
+            font-size: 12px;
+            margin: -7px;
+            margin-bottom: 0;
+            background-color: #c00;
+            color: #fff;
+        }
+
+        ul li {
+            font-size: 12px;
+            list-style: square;
+        }
+    }
+
 }

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -5,24 +5,28 @@ form > div, .form-fields {
         border-bottom: solid 1px;
     }
 
+    label {
+        display: block;
+
+        padding-bottom: 1em;
+
+        span {
+            display: inline-block;
+
+            width: 8em;
+
+            padding-left: 0.5em;
+        }
+
+        ul {
+            margin: 0em;
+
+            list-style: none;
+        }
+    }
+
     &.actions, &.field {
         margin-bottom: 10px;
-    }
-}
-
-form > label, .form-label {
-    display: block;
-
-    padding-bottom: 1em;
-
-    span {
-        display: inline-block;
-        width: 8em;
-    }
-
-    ul {
-        margin: 0em;
-        list-style: none;
     }
 }
 

--- a/app/assets/stylesheets/_forms.scss
+++ b/app/assets/stylesheets/_forms.scss
@@ -1,84 +1,77 @@
-form {
-    div {
-        h4 {
-            width: 33%;
+form > div, .form-fields {
+    h4 {
+        width: 33%;
 
-            border-bottom: solid 1px;
-        }
-
-        &.actions, &.field {
-            margin-bottom: 10px;
-        }
+        border-bottom: solid 1px;
     }
 
-    label {
-        display: block;
+    &.actions, &.field {
+        margin-bottom: 10px;
+    }
+}
 
-        padding-bottom: 1em;
+form > label, .form-label {
+    display: block;
 
-        span {
-            display: inline-block;
-            width: 8em;
-        }
+    padding-bottom: 1em;
 
-        ul {
-            margin: 0em;
-            list-style: none;
-        }
+    span {
+        display: inline-block;
+        width: 8em;
     }
 
-    input, select {
-        &.small {
-            width: 5em;
-        }
+    ul {
+        margin: 0em;
+        list-style: none;
+    }
+}
 
-        &.medium {
-            width: 7em;
-        }
-
-        &.large {
-            width: 10em;
-        }
-
-        &.disabled {
-            color: rgba(0, 0, 0, 0.5);
-            pointer-events: none;
-        }
+input, select {
+    &.small {
+        width: 5em;
     }
 
-    #notice {
-        color: green;
+    &.medium {
+        width: 7em;
     }
 
-    .field_with_errors {
-        padding: 2px;
-        background-color: red;
-        display: table;
+    &.large {
+        width: 10em;
     }
 
-    #error_explanation {
-        width: 450px;
-        border: 2px solid red;
-        padding: 7px;
-        padding-bottom: 0;
-        margin-bottom: 20px;
-        background-color: #f0f0f0;
+    &.disabled {
+        color: rgba(0, 0, 0, 0.5);
+        pointer-events: none;
+    }
+}
 
-        h2 {
-            text-align: left;
-            font-weight: bold;
-            padding: 5px 5px 5px 15px;
-            font-size: 12px;
-            margin: -7px;
-            margin-bottom: 0;
-            background-color: #c00;
-            color: #fff;
-        }
+.field_with_errors {
+    padding: 2px;
+    background-color: red;
+    display: table;
+}
 
-        ul li {
-            font-size: 12px;
-            list-style: square;
-        }
+#error_explanation {
+    width: 450px;
+    border: 2px solid red;
+    padding: 7px;
+    padding-bottom: 0;
+    margin-bottom: 20px;
+    background-color: #f0f0f0;
+
+    h2 {
+        text-align: left;
+        font-weight: bold;
+        padding: 5px 5px 5px 15px;
+        font-size: 12px;
+        margin: -7px;
+        margin-bottom: 0;
+        background-color: #c00;
+        color: #fff;
     }
 
+    ul li {
+        font-size: 12px;
+        list-style: square;
+    }
 }

--- a/app/assets/stylesheets/_layout.scss
+++ b/app/assets/stylesheets/_layout.scss
@@ -41,3 +41,8 @@ footer {
 #main {
     min-height: calc(100vh - 12em);
 }
+
+
+#notice {
+    color: green;
+}

--- a/app/controllers/category_exclusions_controller.rb
+++ b/app/controllers/category_exclusions_controller.rb
@@ -1,3 +1,12 @@
 # Manages AJAX requests to add additional exclusion fields
 class CategoryExclusionsController < ApplicationController
+  # Renders out the form fields for an AJAX query
+  def form_fields
+    locals = {
+      parent_model: Ledger.new,
+      child_index: params[:child_index],
+      exclusions: [CategoryExclusion.new]
+    }
+    render partial: 'form_fields', locals: locals
+  end
 end

--- a/app/controllers/category_exclusions_controller.rb
+++ b/app/controllers/category_exclusions_controller.rb
@@ -1,0 +1,3 @@
+# Manages AJAX requests to add additional exclusion fields
+class CategoryExclusionsController < ApplicationController
+end

--- a/app/controllers/concerns/ledger_summary.rb
+++ b/app/controllers/concerns/ledger_summary.rb
@@ -8,7 +8,7 @@ module LedgerSummary
 
   def generate_totals(ledger, totals)
     nweeks = number_of_weeks(ledger)
-    transactions = ledger.transactions.where.not(category: 'Discover')
+    transactions = ledger.transactions_not_excluded_from('ledger_summary')
     deposits = CategorySummary.new('Deposit', transactions, nweeks)
     #
     {

--- a/app/controllers/concerns/week_total.rb
+++ b/app/controllers/concerns/week_total.rb
@@ -45,14 +45,9 @@ class WeekTotal
     # add the transaction to appropriate array
     if skip_transaction?(transaction)
       @skipped_transactions << transaction
-      return
     else
       @transactions << transaction
     end
-
-    # add transaction to a category
-    category = transaction.category.blank? ? 'UNKNOWN' : transaction.category
-    @category_totals[category] << transaction
   end
 
   private
@@ -60,7 +55,6 @@ class WeekTotal
   def initialize(date)
     @date_range = week_date_range(date)
     @total_deficit = 0.0
-    @category_totals = Hash.new { |hash, key| hash[key] = [] }
     @transactions = []
     @skipped_transactions = []
   end
@@ -74,7 +68,7 @@ class WeekTotal
   def skip_transaction?(transaction)
     if transaction.amount.blank?
       true
-    elsif transaction.category.match?(/^Discover$/i)
+    elsif transaction.excluded_from?('week_total')
       true
     end
   end

--- a/app/controllers/ledgers_controller.rb
+++ b/app/controllers/ledgers_controller.rb
@@ -14,7 +14,7 @@ class LedgersController < ApplicationController
     @page_links = ledger_page_links
     @page_links[0][:url] = root_path
     #
-    @transactions = Transaction.where(ledger_id: @ledger.id).order(date: :asc)
+    @transactions = @ledger.transactions.order(date: :asc)
     @column_names = Transaction.display_columns
     @totals = create_totals_hash(@transactions)
     @totals_column_names = totals_column_names

--- a/app/controllers/ledgers_controller.rb
+++ b/app/controllers/ledgers_controller.rb
@@ -85,6 +85,8 @@ class LedgersController < ApplicationController
     params.require(:ledger).permit(
       :name,
       :data_source,
+      category_exclusions_attributes:
+        %i[category excluded_from ledger_id id _destroy],
       ledger_uploads_attributes: %i[data_source upload_format account]
     )
   end

--- a/app/models/category_exclusion.rb
+++ b/app/models/category_exclusion.rb
@@ -1,0 +1,2 @@
+class CategoryExclusion < ApplicationRecord
+end

--- a/app/models/category_exclusion.rb
+++ b/app/models/category_exclusion.rb
@@ -1,2 +1,4 @@
+# Used to filter ledger transactions based on categories
 class CategoryExclusion < ApplicationRecord
+  belongs_to :ledger, inverse_of: :category_exclusions
 end

--- a/app/models/ledger.rb
+++ b/app/models/ledger.rb
@@ -32,4 +32,16 @@ class Ledger < ApplicationRecord
   def download_data
     to_tab_delim(transactions)
   end
+
+  # Returns all transactions except those with a category excluded
+  # by the category exclusions group passed in.
+  #
+  # @param [String, Array<String>]  exclusion'excluded_from' values to match
+  #
+  # @return [ActiveRecord_Relation<Transaction>]
+  #
+  def transactions_excluding(exclusion = 'all')
+    excluded_cats = category_exclusions.where(excluded_from: exclusion)
+    transactions.where.not(category: excluded_cats.pluck(:category))
+  end
 end

--- a/app/models/ledger.rb
+++ b/app/models/ledger.rb
@@ -10,7 +10,8 @@ class Ledger < ApplicationRecord
                                 }
 
   has_many :category_exclusions, inverse_of: :ledger, dependent: :destroy
-  accepts_nested_attributes_for :category_exclusions, allow_destroy: true,
+  accepts_nested_attributes_for :category_exclusions,
+                                allow_destroy: true,
                                 reject_if: proc { |attributes|
                                   chk = %i[category excluded_from]
                                   attributes.values_at(*chk).any?(&:blank?)

--- a/app/models/ledger.rb
+++ b/app/models/ledger.rb
@@ -10,7 +10,7 @@ class Ledger < ApplicationRecord
                                 }
 
   has_many :category_exclusions, inverse_of: :ledger, dependent: :destroy
-  accepts_nested_attributes_for :category_exclusions,
+  accepts_nested_attributes_for :category_exclusions, allow_destroy: true,
                                 reject_if: proc { |attributes|
                                   chk = %i[category excluded_from]
                                   attributes.values_at(*chk).any?(&:blank?)

--- a/app/models/ledger.rb
+++ b/app/models/ledger.rb
@@ -36,12 +36,16 @@ class Ledger < ApplicationRecord
   # Returns all transactions except those with a category excluded
   # by the category exclusions group passed in.
   #
-  # @param [String, Array<String>]  exclusion'excluded_from' values to match
+  # @param [Array<String>] exclusions 'excluded_from' values to match
   #
   # @return [ActiveRecord_Relation<Transaction>]
   #
-  def transactions_excluding(exclusion = 'all')
-    excluded_cats = category_exclusions.where(excluded_from: exclusion)
+  def transactions_excluding(*exclusions)
+    # we always want to exclude 'all' because it should be excluded from
+    # everywhere.
+    exclusions << 'all' unless exclusions.include? 'all'
+    #
+    excluded_cats = category_exclusions.where(excluded_from: exclusions)
     transactions.where.not(category: excluded_cats.pluck(:category))
   end
 end

--- a/app/models/ledger.rb
+++ b/app/models/ledger.rb
@@ -48,4 +48,21 @@ class Ledger < ApplicationRecord
     excluded_cats = category_exclusions.where(excluded_from: exclusions)
     transactions.where.not(category: excluded_cats.pluck(:category))
   end
+
+  # Checks if an individual transaction is excluded from the group
+  #
+  # @param [Transaction] transaction to check
+  # @param [Array<String>] exclusions 'excluded_from' values to match
+  #
+  # @return [Boolean]
+  #
+  def transaction_excluded_from?(transaction, *exclusions)
+    # we always want to exclude 'all' because it should be excluded from
+    # everywhere.
+    exclusions << 'all' unless exclusions.include? 'all'
+    excluded_cats = category_exclusions.where(excluded_from: exclusions)
+
+    # Check if transaction category is in exclusion set
+    transaction.category.in? excluded_cats.pluck(:category)
+  end
 end

--- a/app/models/ledger.rb
+++ b/app/models/ledger.rb
@@ -9,6 +9,13 @@ class Ledger < ApplicationRecord
                                   attributes['data_source'].blank?
                                 }
 
+  has_many :category_exclusions, inverse_of: :ledger, dependent: :destroy
+  accepts_nested_attributes_for :category_exclusions,
+                                reject_if: proc { |attributes|
+                                  chk = %i[category excluded_from]
+                                  attributes.values_at(*chk).any?(&:blank?)
+                                }
+
   has_many :budget_ledgers, inverse_of: :ledger, dependent: :destroy
 
   has_many :budgets, through: :budget_ledgers

--- a/app/models/ledger.rb
+++ b/app/models/ledger.rb
@@ -40,7 +40,7 @@ class Ledger < ApplicationRecord
   #
   # @return [ActiveRecord_Relation<Transaction>]
   #
-  def transactions_excluding(*exclusions)
+  def transactions_not_excluded_from(*exclusions)
     # we always want to exclude 'all' because it should be excluded from
     # everywhere.
     exclusions << 'all' unless exclusions.include? 'all'

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -36,6 +36,18 @@ class Transaction < ApplicationRecord
     @display_data['validated'] = validated ? 'YES' : 'NO'
   end
 
+  # Calls the ledger method to check if this is an excluded transactions
+  # passing `self` into the methd.
+  # @see Ledger#transaction_excluded_from?
+  #
+  # @param [Array<String>] exclusions 'excluded_from' values to match
+  #
+  # @return [Boolean]
+  #
+  def excluded_from?(*exclusions)
+    ledger.transaction_excluded_from?(self, *exclusions)
+  end
+
   # checks for transactions sharing the same amount and a date
   def possible_dupes
     where = [

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -9,7 +9,7 @@ class Transaction < ApplicationRecord
     distinct.where("category REGEXP '.+'").pluck(:category)
   })
   scope(:subcategories, lambda {
-    distinct.where("subcategory REGEXP '.+'").pluck(:category)
+    distinct.where("subcategory REGEXP '.+'").pluck(:subcategory)
   })
 
   auto_strip_attributes :category, :subcategory, :comments, :account,

--- a/app/views/category_exclusions/_form_fields.html.erb
+++ b/app/views/category_exclusions/_form_fields.html.erb
@@ -10,6 +10,10 @@
 
                 <% if exc.object.persisted? %>
                     <span>Delete:</span> <%= exc.check_box :_destroy%>
+                <% else %>
+                    <a class="remove" onclick="$(this).closest('.form-fields').remove()">
+                        <%= render 'shared/icon', name: 'cross' %>
+                    </a>
                 <% end %>
             </label>
         </div>

--- a/app/views/category_exclusions/_form_fields.html.erb
+++ b/app/views/category_exclusions/_form_fields.html.erb
@@ -1,0 +1,17 @@
+<%= fields_for parent_model do |f| %>
+    <%= f.fields_for :category_exclusions, exclusions, child_index: child_index  do |exc| %>
+        <div class='form-fields'>
+            <label>
+                <span>Category:</span>
+                <%= exc.select :category, Transaction.categories.sort.collect { |c| [c.titleize, c] } %>
+
+                <span>Excluded From:</span>
+                <%= exc.select :excluded_from, [['All', 'all']], placeholder: true %>
+
+                <% if exc.object.persisted? %>
+                    <span>Delete:</span> <%= exc.check_box :_destroy%>
+                <% end %>
+            </label>
+        </div>
+    <% end %>
+<% end %>

--- a/app/views/category_exclusions/_form_fields.html.erb
+++ b/app/views/category_exclusions/_form_fields.html.erb
@@ -1,3 +1,9 @@
+<% exclusion_opts = [
+    ['All', 'all'],
+    ['Weekly Totals', 'week_total'],
+    ['Ledger Summaries', 'ledger_summary']
+] %>
+
 <%= fields_for parent_model do |f| %>
     <%= f.fields_for :category_exclusions, exclusions, child_index: child_index  do |exc| %>
         <div class='form-fields'>
@@ -6,7 +12,7 @@
                 <%= exc.select :category, Transaction.categories.sort.collect { |c| [c.titleize, c] } %>
 
                 <span>Excluded From:</span>
-                <%= exc.select :excluded_from, [['All', 'all']], placeholder: true %>
+                <%= exc.select :excluded_from, exclusion_opts, placeholder: true %>
 
                 <% if exc.object.persisted? %>
                     <span>Delete:</span> <%= exc.check_box :_destroy%>

--- a/app/views/ledgers/_form.html.erb
+++ b/app/views/ledgers/_form.html.erb
@@ -20,6 +20,20 @@
             <span>Name:</span>
             <%= f.text_field :name %>
          <% end %>
+
+         <%= f.label :category_exclusions do %>
+            Category Exclusions:
+            <br />
+             <% locals = {
+               parent_model: @ledger,
+               child_index: nil,
+               exclusions: @ledger.category_exclusions
+             } %>
+             <div id="category-exclusions-container">
+                 <%= render 'category_exclusions/form_fields', locals %>
+             </div>
+             <a id="add-category-exclusion">Add Exclusion</a>
+         <% end %>
     </div>
 
     <br>
@@ -35,7 +49,7 @@
                 <span>Data Source:</span>
                 <%= upload.file_field :data_source %>
             <% end %>
-            
+
             <%= upload.label :upload_format do %>
                 <span>Data Format:</span>
                 <%= upload.select :upload_format, parser_options %>

--- a/app/views/ledgers/_form.html.erb
+++ b/app/views/ledgers/_form.html.erb
@@ -15,6 +15,7 @@
     <% end %>
 
     <div>
+        <h4>Ledger Parameters</h4>
         <%= f.label :name do %>
             <span>Name:</span>
             <%= f.text_field :name %>
@@ -23,19 +24,18 @@
 
     <br>
     <div>
+        <h4>Data Upload Parameters</h4>
         <%= f.fields_for :ledger_uploads,  @ledger.ledger_uploads.build do |upload| %>
             <%= upload.label :account do %>
                 <span>Account Name:</span>
                 <%= upload.text_field :account %>
             <% end %>
-            <br>
-            <br>
+
             <%= upload.label :data_source do %>
                 <span>Data Source:</span>
                 <%= upload.file_field :data_source %>
             <% end %>
-            <br>
-            <br>
+            
             <%= upload.label :upload_format do %>
                 <span>Data Format:</span>
                 <%= upload.select :upload_format, parser_options %>
@@ -44,7 +44,10 @@
     </div>
 
     <br>
-    <%= f.submit %>
+
+    <div class="actions">
+        <%= f.submit %>
+    </div>
 <% end %>
 
 <br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,4 +36,8 @@ Rails.application.routes.draw do
       get 'add-category-initializer'
     end
   end
+
+  controller :category_exclusions do
+    get 'category_exclusions/form_fields'
+  end
 end

--- a/db/migrate/20171012222305_create_category_exclusions.rb
+++ b/db/migrate/20171012222305_create_category_exclusions.rb
@@ -1,0 +1,11 @@
+class CreateCategoryExclusions < ActiveRecord::Migration[5.0]
+  def change
+    create_table :category_exclusions do |t|
+      t.references :ledger, foreign_key: true, index: true
+      t.string :category, null: false
+      t.string :excluded_from, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170811013522) do
+ActiveRecord::Schema.define(version: 20171012222305) do
 
   create_table "budget_expenses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.date     "date"
@@ -36,6 +36,15 @@ ActiveRecord::Schema.define(version: 20170811013522) do
     t.datetime "updated_at",                               null: false
     t.string   "name"
     t.float    "initial_balance", limit: 24, default: 0.0
+  end
+
+  create_table "category_exclusions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer  "ledger_id"
+    t.string   "category",      null: false
+    t.string   "excluded_from", null: false
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+    t.index ["ledger_id"], name: "index_category_exclusions_on_ledger_id", using: :btree
   end
 
   create_table "category_initializers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -83,5 +92,6 @@ ActiveRecord::Schema.define(version: 20170811013522) do
   add_foreign_key "budget_expenses", "budgets"
   add_foreign_key "budget_ledgers", "budgets"
   add_foreign_key "budget_ledgers", "ledgers"
+  add_foreign_key "category_exclusions", "ledgers"
   add_foreign_key "ledger_uploads", "ledgers"
 end

--- a/test/controllers/category_exclusions_controller_test.rb
+++ b/test/controllers/category_exclusions_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CategoryExclusionsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/category_exclusions.yml
+++ b/test/fixtures/category_exclusions.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  ledger: 
+  category: MyString
+  excluded_from: MyString
+
+two:
+  ledger: 
+  category: MyString
+  excluded_from: MyString

--- a/test/models/category_exclusion_test.rb
+++ b/test/models/category_exclusion_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CategoryExclusionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Fixes #12 

Categories of transactions can now be ignored from everything, week totals and ledger totals. Additional areas to define exclusions may arise later but I only replaced methods where I used to manually exclude the 'Discover' category.