### PR TITLE
Hide ledger edit fields when only uploading data

### DIFF
--- a/app/controllers/ledgers_controller.rb
+++ b/app/controllers/ledgers_controller.rb
@@ -94,7 +94,7 @@ class LedgersController < ApplicationController
   def ledger_page_links
     [
       { name: 'Back', url: @ledger },
-      { name: 'Upload Data', url: [:edit, @ledger] },
+      { name: 'Upload Data', url: [:edit, @ledger, { upload: true }] },
       { name: 'View All Uploads', url: [@ledger, :ledger_uploads] },
       { name: 'View Summary', url: [:summary, @ledger] },
       { name: 'Download Ledger', url: "#{ledger_path}/download",

--- a/app/views/ledgers/_form.html.erb
+++ b/app/views/ledgers/_form.html.erb
@@ -14,7 +14,7 @@
         </div>
     <% end %>
 
-    <div>
+    <%= content_tag :div do %>
         <h4>Ledger Parameters</h4>
         <%= f.label :name do %>
             <span>Name:</span>
@@ -34,7 +34,7 @@
              </div>
              <a id="add-category-exclusion" class="button">Add Exclusion</a>
          <% end %>
-    </div>
+    <% end unless upload %>
 
     <br>
     <div>

--- a/app/views/ledgers/edit.html.erb
+++ b/app/views/ledgers/edit.html.erb
@@ -18,4 +18,4 @@
     </ul>
 </div>
 
-<%= render 'form' %>
+<%= render 'form', upload: params[:upload] %>

--- a/app/views/ledgers/new.html.erb
+++ b/app/views/ledgers/new.html.erb
@@ -1,1 +1,1 @@
-<%= render 'form' %>
+<%= render 'form', upload: false %>


### PR DESCRIPTION
This is a visual tweak that makes the form easier to work with. You an always upload data when editing a ledger but the reverse makes things confusing.

Fixes #43 