### PR TITLE
Add save and continue button to upload form

### DIFF
--- a/app/controllers/ledger_uploads_controller.rb
+++ b/app/controllers/ledger_uploads_controller.rb
@@ -33,13 +33,15 @@ class LedgerUploadsController < ApplicationController
       { name: 'View All Uploads', url: [@ledger, :ledger_uploads] },
       { name: 'View Upload', url: [@ledger, @upload] }
     ]
+    #
+    render 'edit'
   end
 
   def update
-    if @upload.update(upload_params)
+    if @upload.update(upload_params) && params[:continue_editing].blank?
       redirect_to [@ledger, @upload]
     else
-      render 'edit'
+      edit
     end
   end
 

--- a/app/views/ledger_uploads/_form.html.erb
+++ b/app/views/ledger_uploads/_form.html.erb
@@ -34,5 +34,6 @@
     </table>
     <br>
     <%= f.submit %>
+    <%= f.submit name: 'continue_editing', value: 'Save & Continue' %>
     <%= link_to 'Delete Ledger Upload', [@ledger, @upload], method: :delete, class: 'button', data: { confirm: 'Confirm deletion of upload' } %>
 <% end %>


### PR DESCRIPTION
Adds a 'Save & Continue' button to the ledger upload edit form. This is a handy feature to have when editing a large upload.